### PR TITLE
More efficient way to get several random records

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mongoose-simple-random",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "description": "Simple and easy-to-use NodeJS Mongoose Schema plugin to pull random documents",
   "main": "mongoose-simple-random.js",
   "directories": {
@@ -23,6 +23,9 @@
     "url": "https://github.com/larryprice/mongoose-simple-random/issues"
   },
   "homepage": "https://github.com/larryprice/mongoose-simple-random",
+  "dependencies": {
+    "lodash": "^3.10.1"
+  },
   "devDependencies": {
     "chai": "^1.9.1",
     "mocha": "^1.21.4",


### PR DESCRIPTION
Hello! Can you please have a look at my version of the "findRandom" method?

Your algorithm is fast as it uses "skip" option. Yes, the skip value is a random number but documents in the result set are still ordered. So they can't be truly randomised.

In my approach I call your "findOneRandom" method for "limit option value" number of times. To ensure that findOneRandom won't duplicate results I use `_id: {'$nin': _.pluck(itemsFound, '_id')}` in conditions section. That's why I've added lodash dependency in package.json

Please let me know about your thoughts on this. Thanks!
